### PR TITLE
Bug fix: Updated the link in Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a repo to the supposed NOT working link of meta, you can fork this repo 
 ## Table of contents
 
 - [Link](#link)
-- [My process](#my-process)
+- [My process](#the-process)
 
 ### Link
 

--- a/class.md
+++ b/class.md
@@ -147,6 +147,8 @@ Read the instructions of this file in the README.md
   
   - [Ram Santosh] - India. Front-End-Developer
 
+  - [Rinidh](https://github.com/Rinidh) - Meta Frontend Developer Professional Certificate
+
 - ### **S**
 
   - [Savvas Voriazidis](https://github.com/voriazidis) Android development


### PR DESCRIPTION
Disclaimer: I apologize for breaking contribution rules to modify the README.md file.

The link embedded in "My process" in table of contents does not lead to "The Process" heading on the page. I updated the link to do so.